### PR TITLE
Tame header line-height

### DIFF
--- a/gatsby-template/src/components/layout.css
+++ b/gatsby-template/src/components/layout.css
@@ -41,6 +41,15 @@ a,
   text-rendering: optimizeLegibility;
 }
 
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  line-height: 1.1;
+}
+
 h1 {
   font-size: 48px;
   text-align: left;


### PR DESCRIPTION
Header line-heights should be less than paragraph text.

p.s. super cool effort! Love the design & execution of everything!