### PR TITLE
Reduce white space on homepage on smaller screens

### DIFF
--- a/gatsby-template/src/components/main-bio.css
+++ b/gatsby-template/src/components/main-bio.css
@@ -26,6 +26,7 @@
 @media (max-width: 1024px) {
   .main-bio-container {
     flex-wrap: wrap;
+    margin-top: 2em;
   }
   .main-bio {
     order: 1;


### PR DESCRIPTION
On my phone, 1/2 the screen is white