### PR TITLE
Suggestion: Thinner post title text

### DIFF
--- a/gatsby-template/src/components/layout.css
+++ b/gatsby-template/src/components/layout.css
@@ -52,6 +52,7 @@ h6 {
 
 h1 {
   font-size: 48px;
+  font-weight: 300;
   text-align: left;
   margin-bottom: 8px;
 }


### PR DESCRIPTION
Just an experimental suggestion. Please feel free to close this if this does not fit in the design language. Thanks!

Before:  
<img width="872" alt="Screenshot 2019-06-01 at 9 04 36 AM" src="https://user-images.githubusercontent.com/543981/58743321-ac9f1b00-844c-11e9-9fe6-b1420c597c9d.png">

After:  
<img width="830" alt="Screenshot 2019-06-01 at 9 04 28 AM" src="https://user-images.githubusercontent.com/543981/58743320-ac9f1b00-844c-11e9-969f-678eaca917ba.png">