### PR TITLE
fixed : '.git' was not removed while using HTTP link

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,11 +117,11 @@ Happy writing!`)
 
     const remoteURL = repoURL
 
+    //This will be able to remove ".git" from the https links
     if (repoURL.match(/^git@github.com:.*/i)) {
-      repoURL = repoURL
-        .replace(/^git@github.com:.*/i, 'https://github.com/')
-        .replace(/\.git$/i, '')
+      repoURL = repoURL.replace(/^git@github.com:.*/i, 'https://github.com/')
     }
+    repoURL = repoURL.replace(/\.git$/i, '')
 
     return Promise.all([
       fs


### PR DESCRIPTION
ISSUE: I used the HTTP link to my repository while creating the blog. The edit this article on GitHub button was redirecting to the below link, which obviously redirected to 404 
 https://github.com/dbarochiya/blog.git/edit/master/content/xxx/index.md

FIX: I have added the fix which removes the '.git' extension from the GitHub link regardless of the type of the link