### PR TITLE
integrated google analytics

### DIFF
--- a/gatsby-template/config.js
+++ b/gatsby-template/config.js
@@ -21,4 +21,5 @@ module.exports = {
     linkedin: '',
     instagram: '',
   },
+  trackingId: '{{ trackingID }}',
 }

--- a/gatsby-template/gatsby-config.js
+++ b/gatsby-template/gatsby-config.js
@@ -112,5 +112,11 @@ module.exports = {
         ],
       },
     },
+    {
+      resolve: `gatsby-plugin-google-analytics`,
+      options: {
+        trackingId: site.siteMetadata.trackingId,
+      },
+    },
   ],
 }

--- a/gatsby-template/package.json
+++ b/gatsby-template/package.json
@@ -16,6 +16,7 @@
     "gatsby-image": "^2.1.1",
     "gatsby-mdx": "^0.6.3",
     "gatsby-plugin-feed": "^2.2.1",
+    "gatsby-plugin-google-analytics": "^2.0.20",
     "gatsby-plugin-manifest": "^2.1.1",
     "gatsby-plugin-netlify": "^2.0.17",
     "gatsby-plugin-offline": "^2.1.0",


### PR DESCRIPTION
I have added the steps to integrate google analytics, this can also be added as the separate module.

* It will prompt for creating the analytics account after the deployment
* Based on the input from the user, it will update the `trackingId` in the config.js file ( It will be used by Google to generate analytics) 
* Code change will be pushed into the master branch, which will trigger a new netlify build. 

note: I have added this package for integrating the google analytics 
           `"gatsby-plugin-google-analytics": "^2.0.20"`