### PR TITLE
fix: compiles wrong because it has no semicolon

### DIFF
--- a/gatsby-theme/src/components/main-bio.js
+++ b/gatsby-theme/src/components/main-bio.js
@@ -111,7 +111,7 @@ const WebmentionLink = Styled.a`
 
 const Avatar = Styled(Image)`
   margin-bottom: 0;
-  min-width: 150px
+  min-width: 150px;
   border-radius: 100%;
   border: 8px solid ${theme.colors.primary};
 `


### PR DESCRIPTION
Wrong avatar format due to lack of semicolons when compiling the style.